### PR TITLE
We didn't have any fallback-fonts

### DIFF
--- a/src/theming/styles/cssResets.js
+++ b/src/theming/styles/cssResets.js
@@ -53,7 +53,7 @@ export default css`
   h4,
   h5,
   h6 {
-    font-family: ${fontFamily.heading};
+    font-family: ${fontFamily.heading}, Sans-Serif;
     font-weight: ${fontWeight.bold};
     font-size: 1em;
     -webkit-font-smoothing: antialiased;
@@ -98,7 +98,7 @@ export default css`
   optgroup,
   select,
   textarea {
-    font-family: ${fontFamily.body};
+    font-family: ${fontFamily.body}, Sans-Serif;
     font-size: 100%; /* 1 */
     line-height: 1.15; /* 1 */
     margin: 0; /* 2 */

--- a/src/theming/styles/cssResets.js
+++ b/src/theming/styles/cssResets.js
@@ -32,7 +32,7 @@ export default css`
     min-height: 100%;
     box-sizing: border-box;
     background-color: ${color.bg};
-    font-family: ${fontFamily.body};
+    font-family: ${fontFamily.body}, Sans-Serif;
     font-size: 14px;
     color: ${color.text};
     line-height: ${font.lineHeight};


### PR DESCRIPTION
This causes that we can get [FOUT](https://css-tricks.com/fout-foit-foft/) when using custom fonts. Adding sans-serif avoids that this font is a serif font.