### PR TITLE
fix(components): fix issue with input masking

### DIFF
--- a/src/components/Forms/Input/Input.stories.js
+++ b/src/components/Forms/Input/Input.stories.js
@@ -47,6 +47,13 @@ Standard.args = {
   label: "Input"
 }
 
+export const StandardWithLargeNumber = args => <Input {...args} />
+StandardWithLargeNumber.args = {
+  label: "Input",
+  mode: "currency",
+  defaultValue: 1234567
+}
+
 export const FileUpload = args => <Input {...args} />
 FileUpload.args = {
   label: "Fileupload",

--- a/src/components/Forms/Input/PostalCodeInput/__snapshots__/PostalCodeInput.spec.js.snap
+++ b/src/components/Forms/Input/PostalCodeInput/__snapshots__/PostalCodeInput.spec.js.snap
@@ -14,6 +14,7 @@ exports[`PostalCodeInput Snapshots No props 1`] = `
       onKeyUp={[Function]}
       pattern="[0-9]{4}"
       type="text"
+      value=""
     />
   </div>
 </div>

--- a/src/components/Forms/Slider/SliderKeyboardInput/__snapshots__/SliderKeyboardInput.spec.js.snap
+++ b/src/components/Forms/Slider/SliderKeyboardInput/__snapshots__/SliderKeyboardInput.spec.js.snap
@@ -19,6 +19,7 @@ exports[`SliderKeyboardInput Snapshots Name 1`] = `
       onFocus={[Function]}
       onKeyUp={[Function]}
       type="text"
+      value=""
     />
   </div>
   <div
@@ -89,6 +90,7 @@ exports[`SliderKeyboardInput Snapshots No props 1`] = `
       onFocus={[Function]}
       onKeyUp={[Function]}
       type="text"
+      value=""
     />
   </div>
   <div
@@ -166,6 +168,7 @@ exports[`SliderKeyboardInput Snapshots all 1`] = `
       onFocus={[Function]}
       onKeyUp={[Function]}
       type="text"
+      value=""
     />
   </div>
   <div
@@ -242,6 +245,7 @@ exports[`SliderKeyboardInput Snapshots label 1`] = `
       onFocus={[Function]}
       onKeyUp={[Function]}
       type="text"
+      value=""
     />
   </div>
   <div
@@ -312,6 +316,7 @@ exports[`SliderKeyboardInput Snapshots max 1`] = `
       onFocus={[Function]}
       onKeyUp={[Function]}
       type="text"
+      value=""
     />
   </div>
   <div
@@ -382,6 +387,7 @@ exports[`SliderKeyboardInput Snapshots min 1`] = `
       onFocus={[Function]}
       onKeyUp={[Function]}
       type="text"
+      value=""
     />
   </div>
   <div
@@ -453,6 +459,7 @@ exports[`SliderKeyboardInput Snapshots onBlur 1`] = `
       onFocus={[Function]}
       onKeyUp={[Function]}
       type="text"
+      value=""
     />
   </div>
   <div
@@ -523,6 +530,7 @@ exports[`SliderKeyboardInput Snapshots onChange 1`] = `
       onFocus={[Function]}
       onKeyUp={[Function]}
       type="text"
+      value=""
     />
   </div>
   <div
@@ -593,6 +601,7 @@ exports[`SliderKeyboardInput Snapshots showLabel 1`] = `
       onFocus={[Function]}
       onKeyUp={[Function]}
       type="text"
+      value=""
     />
   </div>
   <div
@@ -663,6 +672,7 @@ exports[`SliderKeyboardInput Snapshots step 1`] = `
       onFocus={[Function]}
       onKeyUp={[Function]}
       type="text"
+      value=""
     />
   </div>
   <div
@@ -733,6 +743,7 @@ exports[`SliderKeyboardInput Snapshots value 1`] = `
       onFocus={[Function]}
       onKeyUp={[Function]}
       type="text"
+      value=""
     />
   </div>
   <div

--- a/src/hooks/useInputMask/useInputMask.js
+++ b/src/hooks/useInputMask/useInputMask.js
@@ -19,8 +19,17 @@ export const useInputMask = ({
   const logger = useLogging("useInputMask", debugLevel)
   const caretPosition = useRef(0)
   const timeout = useRef(null)
-  const [value, valueSet] = React.useState({
-    value: controlledValue ?? defaultValue
+  const createMask = resolveMask(mode, logger)
+  const mask = React.useRef(
+    createMask({
+      locale
+    })
+  )
+  const [value, valueSet] = React.useState(() => {
+    if (!mode) {
+      return controlledValue ?? defaultValue
+    }
+    return mask.current(controlledValue ?? defaultValue)
   })
 
   const updateCaret = useCallback(
@@ -85,7 +94,10 @@ export const useInputMask = ({
   }, [controlledValue])
 
   useEffect(() => {
-    if (defaultValue !== value?.rawValue) {
+    if (
+      typeof defaultValue !== "undefined" &&
+      defaultValue !== value?.rawValue
+    ) {
       let value = defaultValue
       if (value === null || value === undefined) {
         value = ""
@@ -93,14 +105,6 @@ export const useInputMask = ({
       handleChange({ target: { value } })
     }
   }, [defaultValue])
-
-  const createMask = resolveMask(mode, logger)
-  const mask = React.useRef(
-    createMask({
-      locale
-    })
-  )
-
   React.useEffect(() => {
     if (!mode) {
       return


### PR DESCRIPTION
Vi kom over et problem med input-komponenten og mode: "currency" der markøren får feil posisjon med verdier større enn 1 million. Har opprettet en test-case i storybook. Se vedlagt video.

https://user-images.githubusercontent.com/42606774/131672017-96bc9215-b265-49f6-ab3f-d99e6b3d0409.mov

